### PR TITLE
BUGFIX: Keybinding was not restricted to the yUML context.

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,5 +1,13 @@
 [  
     {   
-        "keys": ["ctrl+b"], "command": "yuml"   
+    	"keys": ["ctrl+b"],
+    	"command": "yuml",
+    	"context": [
+      		{
+      			"key": "selector",
+      			"operator": "equal",
+      			"operand": "source.yuml"
+  			 }
+  		]
     }  
-]  
+]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,5 +1,13 @@
 [  
     {   
-        "keys": ["super+b"], "command": "yuml"   
+    	"keys": ["super+b"],
+    	"command": "yuml",
+    	"context": [
+      		{
+      			"key": "selector",
+      			"operator": "equal",
+      			"operand": "source.yuml"
+  			 }
+  		]
     }  
-]  
+]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,5 +1,13 @@
 [  
     {   
-        "keys": ["ctrl+b"], "command": "yuml"   
+    	"keys": ["ctrl+b"],
+    	"command": "yuml",
+    	"context": [
+      		{
+      			"key": "selector",
+      			"operator": "equal",
+      			"operand": "source.yuml"
+  			 }
+  		]
     }  
-]  
+]


### PR DESCRIPTION
My apologies, I did not realize that keybindings defined within a plugin are not restricted to the scope of the plugin and therefore the keybinding that I added was interfering with `super+b` outside of the context of the yUML plugin.

To address this, I added a context restriction so that the keybinding is only active when editing yUML files (selector: source.yuml)
